### PR TITLE
Polish for networking-calico release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,9 @@ ifeq ("$(ARCH)","ppc64le")
 	docker commit centos7Tmp calico-build/centos7:latest
 endif
 
+NETWORKING_CALICO_REPO?=https://opendev.org/openstack/networking-calico.git
+NETWORKING_CALICO_CHECKOUT?=master
+
 networking-calico:
-	git clone https://opendev.org/openstack/networking-calico.git
+	git clone $(NETWORKING_CALICO_REPO)
+	cd networking-calico && git checkout $(NETWORKING_CALICO_CHECKOUT)

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -85,6 +85,7 @@ EOF
 	    debver=`git_version_to_rpm ${version}`
 	    debver=`strip_v ${debver}`
 	    rpm_spec=rpm/networking-calico.spec
+	    [ -f ${rpm_spec}.in ] && cp -f ${rpm_spec}.in ${rpm_spec}
 
 	    # Generate RPM version and release.
 	    IFS=_ read ver qual <<< ${debver}

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -68,6 +68,10 @@ EOF
 EOF
 		} > debian/changelog
 
+		# Update PBR_VERSION setting (if present) in
+		# debian/rules.
+		sed -i "s/^export PBR_VERSION=.*$/export PBR_VERSION=${debver}/" debian/rules
+
 		${DOCKER_RUN_RM} -e DEB_VERSION=${debver}~${series} \
 				 calico-build/${series} dpkg-buildpackage -I -S
 	    done

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -79,7 +79,7 @@ EOF
 	    cat <<EOF
 
     +---------------------------------------------------------------------------+
-    | Debs have been built at dist/bionic, dist/xenial and dist/trusty.         |
+    | Debs have been built.                                                     |
     +---------------------------------------------------------------------------+
 
 EOF


### PR DESCRIPTION
Two fixes for all networking-calico deb builds:
- Set PBR_VERSION correctly to the new version.  Previously this was left wrongly as 3.6.0.
- (cosmetic) Fix wrong message about where debs appear

Usability enhancement:
- Support NETWORKING_CALICO_REPO and NETWORKING_CALICO_CHECKOUT vars, to allow building packages from any point in any networking-calico repo.

Alignment with Felix:
- Support the RPM spec in the source repo being *.spec.in instead of *.spec

Goes with, but should not rely on, https://review.opendev.org/#/c/659337/, which
- removes historical change logs
- renames networking-calico.spec to networking-calico.spec.in
- adds RELEASING.md to document how to release networking-calico