### PR TITLE
Set PBR_VERSION as PBR would

### DIFF
--- a/docker-build-images/ubuntu-bionic-build.Dockerfile.amd64
+++ b/docker-build-images/ubuntu-bionic-build.Dockerfile.amd64
@@ -5,5 +5,6 @@ ENV STREAM bionic
 ADD install-ubuntu-build-deps install-ubuntu-build-deps
 RUN ./install-ubuntu-build-deps
 RUN apt-get install -y python-pbr
+RUN apt-get install -y git
 
 WORKDIR /code

--- a/docker-build-images/ubuntu-trusty-build.Dockerfile.amd64
+++ b/docker-build-images/ubuntu-trusty-build.Dockerfile.amd64
@@ -5,5 +5,6 @@ ENV STREAM trusty
 ADD install-ubuntu-build-deps install-ubuntu-build-deps
 RUN ./install-ubuntu-build-deps
 RUN apt-get install -y python-pbr
+RUN apt-get install -y git
 
 WORKDIR /code

--- a/docker-build-images/ubuntu-xenial-build.Dockerfile.amd64
+++ b/docker-build-images/ubuntu-xenial-build.Dockerfile.amd64
@@ -5,5 +5,6 @@ ENV STREAM xenial
 ADD install-ubuntu-build-deps install-ubuntu-build-deps
 RUN ./install-ubuntu-build-deps
 RUN apt-get install -y python-pbr
+RUN apt-get install -y git
 
 WORKDIR /code

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -68,9 +68,16 @@ EOF
 EOF
 		} > debian/changelog
 
+		pbr_version=`${DOCKER_RUN_RM} -e DEB_VERSION=${debver}~${series} -i \
+				 calico-build/${series} python - <<'EOF'
+import pbr.version
+print pbr.version.VersionInfo('networking-calico').release_string()
+EOF`
+		echo PBR-generated version is $pbr_version
+
 		# Update PBR_VERSION setting (if present) in
 		# debian/rules.
-		sed -i "s/^export PBR_VERSION=.*$/export PBR_VERSION=${debver}/" debian/rules
+		sed -i "s/^export PBR_VERSION=.*$/export PBR_VERSION=${pbr_version}/" debian/rules
 
 		${DOCKER_RUN_RM} -e DEB_VERSION=${debver}~${series} \
 				 calico-build/${series} dpkg-buildpackage -I -S


### PR DESCRIPTION
When building a networking-calico package from an arbitrary Git point,
we were setting PBR_VERSION to our full generated version, e.g.

`export PBR_VERSION=3.7.2.post1+20190603224628+0000+87e7801`

This is problematic because it can cause the Neutron server to exit as
in the traceback below.

The reason we have to set PBR_VERSION at all is that our upload to
Launchpad doesn't include the git data.  So, when Launchpad builds, it
can't autodetect the version from Git.  When we're preparing the upload,
however, we do have Git, and so we can set PBR_VERSION to whatever PBR
would autodetect at that point.  This change does that.

Traceback when it fails:
```
Unhandled error: ValueError: invalid literal for int() with base 10: '1-20190602224636-0000-87e7801'
Traceback (most recent call last):
  File "/usr/bin/neutron-server", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/dist-packages/neutron/cmd/eventlet/server/__init__.py", line 19, in main
    server.boot_server(wsgi_eventlet.eventlet_wsgi_server)
  File "/usr/lib/python2.7/dist-packages/neutron/server/__init__.py", line 42, in boot_server
    server_func()
  File "/usr/lib/python2.7/dist-packages/neutron/server/wsgi_eventlet.py", line 24, in eventlet_wsgi_server
    neutron_api = service.serve_wsgi(service.NeutronApiService)
  File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 89, in serve_wsgi
    LOG.exception('Unrecoverable error: please check log '
  File "/usr/lib/python2.7/dist-packages/oslo_utils/excutils.py", line 220, in __exit__
    self.force_reraise()
  File "/usr/lib/python2.7/dist-packages/oslo_utils/excutils.py", line 196, in force_reraise
    six.reraise(self.type_, self.value, self.tb)
  File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 86, in serve_wsgi
    service.start()
  File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 62, in start
    self.wsgi_app = _run_wsgi(self.app_name)
  File "/usr/lib/python2.7/dist-packages/neutron/service.py", line 289, in _run_wsgi
    app = config.load_paste_app(app_name)
  File "/usr/lib/python2.7/dist-packages/neutron/common/config.py", line 122, in load_paste_app
    app = loader.load_app(app_name)
  File "/usr/lib/python2.7/dist-packages/oslo_service/wsgi.py", line 353, in load_app
    return deploy.loadapp("config:%s" % self.config_path, name=name)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 144, in invoke
    **context.local_conf)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/usr/lib/python2.7/dist-packages/paste/urlmap.py", line 31, in urlmap_factory
    app = loader.get_app(app_name, global_conf=global_conf)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 350, in get_app
    name=name, global_conf=global_conf).create()
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 144, in invoke
    **context.local_conf)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/usr/lib/python2.7/dist-packages/neutron/auth.py", line 47, in pipeline_factory
    app = loader.get_app(pipeline[-1])
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 350, in get_app
    name=name, global_conf=global_conf).create()
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/usr/lib/python2.7/dist-packages/neutron/api/v2/router.py", line 25, in _factory
    return pecan_app.v2_factory(global_config, **local_config)
  File "/usr/lib/python2.7/dist-packages/neutron/pecan_wsgi/app.py", line 47, in v2_factory
    startup.initialize_all()
  File "/usr/lib/python2.7/dist-packages/neutron/pecan_wsgi/startup.py", line 39, in initialize_all
    manager.init()
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 296, in init
    NeutronManager.get_instance()
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 247, in get_instance
    cls._create_instance()
  File "/usr/lib/python2.7/dist-packages/oslo_concurrency/lockutils.py", line 277, in inner
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 233, in _create_instance
    cls._instance = cls()
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 132, in __init__
    plugin_provider)
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 165, in _get_plugin_instance
    plugin_class = self.load_class_for_provider(namespace, plugin_provider)
  File "/usr/lib/python2.7/dist-packages/neutron/manager.py", line 159, in load_class_for_provider
    plugin_provider)
  File "/usr/lib/python2.7/dist-packages/neutron_lib/utils/runtime.py", line 46, in load_class_by_alias_or_classname
    namespace, name, warn_on_missing_entrypoint=False)
  File "/usr/lib/python2.7/dist-packages/stevedore/driver.py", line 61, in __init__
    warn_on_missing_entrypoint=warn_on_missing_entrypoint
  File "/usr/lib/python2.7/dist-packages/stevedore/named.py", line 81, in __init__
    verify_requirements)
  File "/usr/lib/python2.7/dist-packages/stevedore/extension.py", line 203, in _load_plugins
    self._on_load_failure_callback(self, ep, err)
  File "/usr/lib/python2.7/dist-packages/stevedore/extension.py", line 195, in _load_plugins
    verify_requirements,
  File "/usr/lib/python2.7/dist-packages/stevedore/named.py", line 158, in _load_one_plugin
    verify_requirements,
  File "/usr/lib/python2.7/dist-packages/stevedore/extension.py", line 223, in _load_one_plugin
    plugin = ep.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python2.7/dist-packages/networking_calico/__init__.py", line 19, in <module>
    'networking-calico').version_string()
  File "/usr/lib/python2.7/dist-packages/pbr/version.py", line 466, in version_string
    return self.semantic_version().brief_string()
  File "/usr/lib/python2.7/dist-packages/pbr/version.py", line 461, in semantic_version
    self._semantic = self._get_version_from_pkg_resources()
  File "/usr/lib/python2.7/dist-packages/pbr/version.py", line 449, in _get_version_from_pkg_resources
    return SemanticVersion.from_pip_string(result_string)
  File "/usr/lib/python2.7/dist-packages/pbr/version.py", line 145, in from_pip_string
    return klass._from_pip_string_unsafe(version_string)
  File "/usr/lib/python2.7/dist-packages/pbr/version.py", line 217, in _from_pip_string_unsafe
    post_count = int(component[4:])
ValueError: invalid literal for int() with base 10: '1-20190602224636-0000-87e7801'
```