### PR TITLE
Fix for missing bin/calico-felix in wavetank run

### DIFF
--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -196,6 +196,8 @@ function do_felix {
     # RPM golang build dependencies that is exactly equivalent to our
     # containerized builds.
     make bin/calico-felix
+    # Remove all the files that were added by that build, except for the
+    # bin/calico-felix binary.
     rm -f bin/calico-felix-amd64
     rm -rf vendor .go-pkg-cache
     PKG_NAME=felix \

--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -196,6 +196,8 @@ function do_felix {
     # RPM golang build dependencies that is exactly equivalent to our
     # containerized builds.
     make bin/calico-felix
+    rm -f bin/calico-felix-amd64
+    rm -rf vendor .go-pkg-cache
     PKG_NAME=felix \
 	    NAME=Felix \
 	    ../utils/make-packages.sh deb rpm

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -42,9 +42,6 @@ for package_type in "$@"; do
 	    # Mar 2016 14:08:51 +0000.
 	    timestamp=`date "+%a, %d %b %Y %H:%M:%S %z"`
 	    for series in trusty xenial bionic; do
-		# Clean the Git repo; but in the Felix case, avoid
-		# deleting the calico-felix binary.
-		git clean -ffxd -e bin/calico-felix
 		{
 		    cat <<EOF
 ${PKG_NAME} (${DEB_EPOCH}${debver}~$series) $series; urgency=low


### PR DESCRIPTION
The wavetank run failed in this way:
```
  + install -m 755 'bin/*' /tmp/rpmbuild/BUILDROOT/felix-3.9.0-0.1.0.dev.post46+20190807105811+0000+505f0a9.el7.x86_64/usr/bin/
  install: cannot stat 'bin/*': No such file or directory
```
And earlier it said:
```
  + git clean -ffxd -e bin/calico-felix
  Removing .go-pkg-cache/
  Removing bin/
  Removing vendor/
```
Whereas running on my own laptop I see:
```
  + git clean -ffxd -e bin/calico-felix
  Removing .go-pkg-cache/
  Removing bin/calico-felix-amd64
  Removing vendor/
```
git on wavetank is 2.11.0, whereas mine is 2.22.0, and the release notes
for 2.14.0 include:
```
 * "git clean -d" used to clean directories that has ignored files,
   even though the command should not lose ignored ones without "-x".
   "git status --ignored"  did not list ignored and untracked files
   without "-uall".  These have been corrected.
```
So I think the git clean on wavetank was ignoring the "-e
bin/calico-felix" and deleting that file.  Therefore let's not use git
clean, and instead delete the files and directories that need cleaning
explicitly.