### PR TITLE
Fix RPM version generation

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -72,7 +72,7 @@ function git_version_to_deb {
 
 # Convert PEP 440 version to RPM.
 function git_version_to_rpm {
-    echo $1 | sed 's/\([0-9]\)-\?\(a\|b\|rc\|pre\|0.dev\)/\1_\2/'
+    echo $1 | sed 's/\([0-9]\)-\?\(0.dev\)/\1_\2/'
 }
 
 # Check that version is valid.


### PR DESCRIPTION
This is the RPM counterpart of the fix for Debian version generation
that I made at
https://github.com/projectcalico/felix/commit/ce7f35d5be57d3940babf328d7ef84410bc5e1f5.
I really should have made the equivalent RPM change at the same time!

Key point here is we no longer use tags with "a" for alpha or "b" for
beta, so we don't need to handle translating those here.  Plus the "a"
and "b" translation was wrong anyway, because it incorrectly matched and
messed up "a" or "b" in the Git commit ID part of the version.