### PR TITLE
Avoid uploading package versions that already exist in PPA

### DIFF
--- a/utils/publish-debs.sh
+++ b/utils/publish-debs.sh
@@ -8,9 +8,24 @@ cp -a $SECRET_KEY ${keydir}/key
 
 docker run --rm -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import < /keydir/key && debsign -kCalico *_*_source.changes"
 for series in trusty xenial bionic; do
+    # Get the packages and versions that already exist in the PPA, so we can avoid
+    # uploading the same package and version as already exist.  (As they would be rejected
+    # anyway by Launchpad.)
+    sources_url="http://ppa.launchpad.net/project-calico/${REPO_NAME}/ubuntu/dists/${series}/main/source/Sources.gz"
+    existing_packages=$(wget -q -O - ${sources_url} | gzip -d | awk '/^Package:/{printf("%s_", $2);} /^Version:/{sub(/^1:/,"", $2); print $2;}')
+    echo "Existing source packages for ${series} in project-calico/${REPO_NAME} are:"
+    echo "${existing_packages}"
+
     # Use the Distribution header to map changes files to Ubuntu versions, as some of our
     # packages don't include the Ubuntu version name in the changes file name.
     for changes_file in `grep -l "Distribution: ${series}" *_source.changes`; do
-	docker run --rm -v `pwd`:/code -w /code calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file}
+	already_exists=false
+	for existing in ${existing_packages}; do
+	    if [ ${changes_file} = ${existing}_source.changes ]; then
+		already_exists=true
+		break
+	    fi
+	done
+	${already_exists} || docker run --rm -v `pwd`:/code -w /code calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file}
     done
 done


### PR DESCRIPTION
Here are the notification emails I get from Launchpad on a typical night:

![2019-08-20-231328_1115x354_scrot](https://user-images.githubusercontent.com/2089263/63388381-28e83100-c3a0-11e9-8c6e-f5b4d440433e.png)

Note the "(Rejected)" ones.  Those are because there's already a package in the PPA with the exact same version.  It's not a massive harm, but it's easy enough to avoid uploading in that case, so this PR does that.