### PR TITLE
Make debsign work for password protected keys

### DIFF
--- a/utils/publish-debs.sh
+++ b/utils/publish-debs.sh
@@ -6,7 +6,7 @@ test -n "$SECRET_KEY"
 keydir=`mktemp -t -d calico-publish-debs.XXXXXX`
 cp -a $SECRET_KEY ${keydir}/key
 
-docker run --rm -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import < /keydir/key && debsign -kCalico *_*_source.changes"
+docker run --rm -ti -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import --batch < /keydir/key && debsign -kCalico *_*_source.changes"
 for series in trusty xenial bionic; do
     # Get the packages and versions that already exist in the PPA, so we can avoid
     # uploading the same package and version as already exist.  (As they would be rejected


### PR DESCRIPTION
Clue was based on these threads:

- https://superuser.com/questions/1325862/gnupg2-suddenly-throwing-error-building-skey-array-no-such-file-or-directory
- https://superuser.com/questions/1135812/gpg2-asking-for-passphrase-when-importing-secret-keys

I was getting the "ioctl" error listed there. 