### PR TITLE
Use a more general debsign key ID match

### DIFF
--- a/utils/publish-debs.sh
+++ b/utils/publish-debs.sh
@@ -6,7 +6,8 @@ test -n "$SECRET_KEY"
 keydir=`mktemp -t -d calico-publish-debs.XXXXXX`
 cp -a $SECRET_KEY ${keydir}/key
 
-docker run --rm -ti -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import --batch < /keydir/key && debsign -kCalico *_*_source.changes"
+# Use '-ktigera' to do a substring match on the key id to match the SECRET_KEY. This will match SECRET_KEY if a @tigera.io email was used for the key.
+docker run --rm -ti -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import --batch < /keydir/key && debsign -ktigera *_*_source.changes"
 for series in trusty xenial bionic; do
     # Get the packages and versions that already exist in the PPA, so we can avoid
     # uploading the same package and version as already exist.  (As they would be rejected


### PR DESCRIPTION
In cutting a release, I ran into an issue where my signing key did not match the pattern expected by the `publish-debs.sh` script.

In chatting with @neiljerram , he pointed out this [reference](https://www.gnupg.org/documentation/manuals/gnupg/Specify-a-User-ID.html) and that:
> That page suggests that *@ might work.  Apparently a leading @ means "By partial match on an email address", so perhaps it needs at least one following character.  A leading * means general substring match, so *@ might mean "anything with an email".

I'm not sure what the best solution is. Is it a pattern? (maybe `-k*@` or `-ktigera` as in this PR).

Or do we just require that the GPG key you use to sign Calico releases contains the string `Calico`?