### PR TITLE
Use current etcd3gw master code, instead of PyPI release 0.2.4

### DIFF
--- a/etcd3gw/rpm/python-etcd3gw.spec
+++ b/etcd3gw/rpm/python-etcd3gw.spec
@@ -6,7 +6,7 @@
 %endif
 
 Name:           python-%{pypi_name}
-Version:        0.2.4
+Version:        0.2.4.1.19abd85
 Release:        1%{?dist}
 Summary:        A python client for etcd3 grpc-gateway
 
@@ -48,7 +48,7 @@ A python client for etcd3 grpc-gateway
 
 %files -n python2-%{pypi_name}
 %license LICENSE
-%doc README.md AUTHORS ChangeLog CONTRIBUTING.rst HACKING.rst
+%doc README.md CONTRIBUTING.rst HACKING.rst
 %defattr(-,root,root,-)
 %{python_sitelib}/%{pypi_name}*
 
@@ -84,4 +84,3 @@ centos-release-openstack-<version> package to install python dependencies.
 
 %install
 %py2_install
-

--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -41,18 +41,25 @@ cp -a ${repo}/rpm/$spec /tmp/rpmbuild/SPECS/
 cd /tmp/rpmbuild/SOURCES
 for f in ${repo}/rpm/*; do ln -sf $f; done
 
+# Infer the version that the spec wants to build.
+version=`grep Version: $spec | head -1 | awk '{print $2;}'`
+
 case ${pkg} in
     felix | networking-calico | dnsmasq )
-	# Infer the version that the spec wants to build.
-	version=`grep Version: $spec | head -1 | awk '{print $2;}'`
-
 	# Tar up the Git source, with the naming that rpmbuild expects.
 	dir=${pkg}-${version}
 	cp -a ${repo} /tmp/$dir
 	tar -C /tmp --exclude-vcs -czf /tmp/rpmbuild/SOURCES/${dir}.tar.gz $dir
 	;;
     etcd3gw)
-	curl https://nero-mirror.stanford.edu/pypi/packages/08/02/63d5eb103943ce18c38dd1b11a2d63e6ff7260d44067458e7faa092c2b9e/etcd3gw-0.2.4.tar.gz -o /tmp/rpmbuild/SOURCES/etcd3gw-0.2.4.tar.gz
+	t=`mktemp -d -t etcd3gw.XXXXXX`
+	curl -L https://github.com/dims/etcd3-gateway/archive/19abd85b710682b326702e2290a30d084fb0af71.zip -o $t/${pkg}-${version}.zip
+	pushd $t
+	unzip ${pkg}-${version}.zip
+	mv etcd3-gateway-19abd85b710682b326702e2290a30d084fb0af71 ${pkg}-${version}
+	tar zcf /tmp/rpmbuild/SOURCES/${pkg}-${version}.tar.gz ${pkg}-${version}
+	popd
+	export PBR_VERSION=${version}
 	;;
 esac
 


### PR DESCRIPTION
We need this for logging extra detail for etcd3 bad responses.