### PR TITLE
Fix problems with tag detection and PBR version setting

### DIFF
--- a/rpm/build-rpms
+++ b/rpm/build-rpms
@@ -21,10 +21,21 @@ if [ ${pkg} = networking-calico ]; then
     # --exclude-vcs) from the source tarball that we pass to rpmbuild,
     # so we calculate PBR_VERSION now and then add that to the
     # environment for rpmbuild.
-    export PBR_VERSION=`python - <<'EOF'
+    if [ "$FORCE_VERSION" ]; then
+	# When FORCE_VERSION is specified, that is also the PBR version
+	# that we should set.  Note: this is relevant in particular when
+	# there are multiple version tags on the same networking-calico
+	# commit (which is quite common as networking-calico doesn't
+	# change much).  The alternative, automated method, just below,
+	# is currently broken when there are multiple tags on the same
+	# commit; see https://bugs.launchpad.net/pbr/+bug/1453996.
+	export PBR_VERSION=$FORCE_VERSION
+    else
+	export PBR_VERSION=`python - <<'EOF'
 import pbr.version
 print pbr.version.VersionInfo('networking-calico').release_string()
 EOF`
+    fi
 fi
 
 mkdir -p /tmp/rpmbuild/BUILD \

--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -167,6 +167,13 @@ function do_net_cal {
     NETWORKING_CALICO_REPO=${NETWORKING_CALICO_REPO:-https://opendev.org/openstack/networking-calico.git}
     git clone $NETWORKING_CALICO_REPO -b $NETWORKING_CALICO_CHECKOUT
     cd networking-calico
+    # When NETWORKING_CALICO_CHECKOUT is a Git tag, set FORCE_VERSION
+    # to ensure that we build packages with version equal to _that_
+    # tag.  Otherwise, if there are other tags on the checkout commit,
+    # we might pick up one of those by mistake.
+    if [ "`git tag -l $NETWORKING_CALICO_CHECKOUT --points-at`" = $NETWORKING_CALICO_CHECKOUT ]; then
+	export FORCE_VERSION=$NETWORKING_CALICO_CHECKOUT
+    fi
     PKG_NAME=networking-calico \
 	    NAME=networking-calico \
 	    DEB_EPOCH=1: \


### PR DESCRIPTION
We were seeing this:

   ValueError: git history requires a target version of
   pbr.version.SemanticVersion(3.9.2), but target version is
   pbr.version.SemanticVersion(3.8.4)

when building networking-calico packages from a commit with multiple
version tags.

The context for that was releasing a particular patch version, 3.8.4,
so the general fix is that when we know the version we're releasing,
skip the autodetection logic and just use that version.