### PR TITLE
Use -DISTRO suffix instead of ~DISTRO for Ubuntu distribution names

### DIFF
--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -44,7 +44,7 @@ for package_type in "$@"; do
 	    for series in trusty xenial bionic; do
 		{
 		    cat <<EOF
-${PKG_NAME} (${DEB_EPOCH}${debver}~$series) $series; urgency=low
+${PKG_NAME} (${DEB_EPOCH}${debver}-$series) $series; urgency=low
 
 EOF
 		    if ${release}; then


### PR DESCRIPTION
With the current ~DISTRO suffix, we're hitting this (from Launchpad):
```
  Rejected:
  networking-calico_3.11.2~bionic.dsc: Version older than that in the archive. 1:3.11.2~bionic <= 1:3.11.2~dev1~bionic

  networking-calico (1:3.11.2~bionic) bionic; urgency=low

    * networking-calico 3.11.2 (from Git commit 594cf28).
```
Logically, the new 3.11.2 package is newer than the existing
`3.11.2~dev1` package and so should replace it.  The problem is that we
are misusing `~` for the `~bionic` suffix.  In Debian, `VER~SUFFIX` means
something that comes _before_ VER, like a pre-release, and that is not
actually the case for the package that we are versioning (wrongly) as
`3.11.2~bionic`.  The fix is to version it instead as `3.11.2-bionic`,
which means something that comes after 3.11.2, and generally to use
`-DISTRO` as our distro-distinguishing suffix instead of `~DISTRO`.