### PR TITLE
Fix tilde translation for Debian version for master packages

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -52,33 +52,13 @@ function strip_v {
 	echo $1 | sed 's/^v//'
 }
 
-# Convert PEP 440 version to Debian.
 function git_version_to_deb {
-    # We don't any more use pre-release versions in the form that the
-    # previous regexp here was trying to match.  Instead when
-    # developing for, say, 3.7.0, the base tag is 3.7.0-0.dev.  For
-    # Debian we _should_ translate that to 3.7.0~0.dev (because it's
-    # logically _before_ 3.7.0), and we could achieve that by adding
-    # "\|0.dev" to the previous regexp here.  However switching now
-    # from 3.7.0-0.dev to 3.7.0~0.dev would cause the PPA to reject
-    # all our new package uploads, until 3.7.0 is released and we move
-    # onto a higher version number.
-    #
-    # Meanwhile, the previous regexp here was accidentally matching
-    # and corrupting the Git ID later in the version; for example it
-    # changed "...+fce1a58" to "...+fce1~a58".
-    #
-    # So, for now, the best thing is no change at all.  As soon as our
-    # base version is 3.7.1 (or 3.8.0, or 4.0.0), we should do the
-    # correct tilde translation.
-    if [[ "$1" < "v3.7.1" ]]; then
-	echo $1
-    else
-	echo $1 | sed 's/\([0-9]\)-0.dev/\1~0.dev/'
-    fi
+    # Our mainline development tags now look like 'v3.14.0-0.dev'.
+    # For the Debian package version, translate that to v3.14.0~0.dev,
+    # because it's logically _before_ v3.14.0.
+    echo $1 | sed 's/\([0-9]\)-0.dev/\1~0.dev/'
 }
 
-# Convert PEP 440 version to RPM.
 function git_version_to_rpm {
     echo $1 | sed 's/\([0-9]\)-\?\(0.dev\)/\1_\2/'
 }


### PR DESCRIPTION
Right now is a good time to do this, because we've just switched to
3.14.0-0.dev and we haven't yet successfully uploaded any 3.14.0-0.dev
packages to the master PPA at
https://launchpad.net/~project-calico/+archive/ubuntu/master.