### PR TITLE
Ensure that $version here does not have initial 'v'

### DIFF
--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -13,6 +13,7 @@ scriptdir=$(dirname $(realpath $0))
 
 # Get the version based on Git state, and the Git commit ID.
 version=${FORCE_VERSION:-`git_auto_version`}
+version=`strip_v ${version}`
 sha=`git_commit_id`
 
 MY_UID=`id -u`


### PR DESCRIPTION
For networking-calico, this means we generate a version without 'v' in
setup.py, as we always have done previously.

For both Felix and networking-calico, it means that the Changelog text
has a single 'v' and not a double 'vv'.

Otherwise there should be no other effects of this change.