### PR TITLE
Support release branches

### DIFF
--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -48,6 +48,10 @@ function require_version {
 	: ${REPO_NAME:=master}
 	: ${NETWORKING_CALICO_CHECKOUT:=master}
 	: ${FELIX_CHECKOUT:=master}
+    elif [[ $VERSION =~ ^release-v ]]; then
+	: ${REPO_NAME:=testing}
+	: ${NETWORKING_CALICO_CHECKOUT:=${VERSION}}
+	: ${FELIX_CHECKOUT:=${VERSION}}
     elif [[ $VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
 	MAJOR=${BASH_REMATCH[1]}
 	MINOR=${BASH_REMATCH[2]}


### PR DESCRIPTION
Support packaging release branches, with `VERSION=release-vX.Y`.  By default packages go to the "testing" PPA/repo, but this can be overridden by setting `REPO_NAME`.