### PR TITLE
Packaging improvements for v3.15

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,9 +32,11 @@ blocks:
           commands:
             - export REPO_NAME=calico-current
             - export VERSION=release-v3.14
+            - export PACKAGE_ETCD3GW=true
             - make release-publish
         - name: 'Previous release branch'
           commands:
             - export REPO_NAME=calico-previous
             - export VERSION=release-v3.13
+            - export PACKAGE_ETCD3GW=true
             - make release-publish

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ blocks:
   - name: 'Packaging'
     task:
       jobs:
-        - name: 'Update master packages'
+        - name: 'Master'
           commands:
             - checkout
             - git config --global user.email marvin@tigera.io
@@ -19,6 +19,34 @@ blocks:
             - export SECRET_KEY=$HOME/secrets/marvin.txt
             - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
             - export HOST=ubuntu@binaries-projectcalico-org
+            - make release-publish
+        - name: 'Current release branch'
+          commands:
+            - checkout
+            - git config --global user.email marvin@tigera.io
+            - git config --global user.name Marvin
+            - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
+            - gcloud config set project tigera-wp-tcp-redirect
+            - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+            - export SECRET_KEY=$HOME/secrets/marvin.txt
+            - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
+            - export HOST=ubuntu@binaries-projectcalico-org
+            - export REPO_NAME=calico-current
+            - export VERSION=release-v3.14
+            - make release-publish
+        - name: 'Previous release branch'
+          commands:
+            - checkout
+            - git config --global user.email marvin@tigera.io
+            - git config --global user.name Marvin
+            - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
+            - gcloud config set project tigera-wp-tcp-redirect
+            - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+            - export SECRET_KEY=$HOME/secrets/marvin.txt
+            - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
+            - export HOST=ubuntu@binaries-projectcalico-org
+            - export REPO_NAME=calico-previous
+            - export VERSION=release-v3.13
             - make release-publish
       secrets:
         - name: google-service-account-for-tigera-infra

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,50 +4,37 @@ agent:
   machine:
     type: e1-standard-4
     os_image: ubuntu1804
+
+global_job_config:
+  secrets:
+    - name: google-service-account-for-tigera-infra
+    - name: launchpad-secret-key
+  prologue:
+    commands:
+      - checkout
+      - git config --global user.email marvin@tigera.io
+      - git config --global user.name Marvin
+      - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
+      - gcloud config set project tigera-wp-tcp-redirect
+      - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+      - export SECRET_KEY=$HOME/secrets/marvin.txt
+      - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
+      - export HOST=ubuntu@binaries-projectcalico-org
+
 blocks:
   - name: 'Packaging'
     task:
       jobs:
         - name: 'Master'
           commands:
-            - checkout
-            - git config --global user.email marvin@tigera.io
-            - git config --global user.name Marvin
-            - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
-            - gcloud config set project tigera-wp-tcp-redirect
-            - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-            - export SECRET_KEY=$HOME/secrets/marvin.txt
-            - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
-            - export HOST=ubuntu@binaries-projectcalico-org
             - make release-publish
         - name: 'Current release branch'
           commands:
-            - checkout
-            - git config --global user.email marvin@tigera.io
-            - git config --global user.name Marvin
-            - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
-            - gcloud config set project tigera-wp-tcp-redirect
-            - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-            - export SECRET_KEY=$HOME/secrets/marvin.txt
-            - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
-            - export HOST=ubuntu@binaries-projectcalico-org
             - export REPO_NAME=calico-current
             - export VERSION=release-v3.14
             - make release-publish
         - name: 'Previous release branch'
           commands:
-            - checkout
-            - git config --global user.email marvin@tigera.io
-            - git config --global user.name Marvin
-            - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
-            - gcloud config set project tigera-wp-tcp-redirect
-            - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-            - export SECRET_KEY=$HOME/secrets/marvin.txt
-            - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
-            - export HOST=ubuntu@binaries-projectcalico-org
             - export REPO_NAME=calico-previous
             - export VERSION=release-v3.13
             - make release-publish
-      secrets:
-        - name: google-service-account-for-tigera-infra
-        - name: launchpad-secret-key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,6 +28,17 @@ blocks:
         - name: 'Master'
           commands:
             - make release-publish
+        - name: 'v3.15 Python 2 branch'
+          # This is a special case, probably (hopefully!) for v3.15
+          # only: we have 2 separate PPAs for Python 2 and Python 3,
+          # and corresponding separate branches in the
+          # networking-calico repo.
+          commands:
+            - export REPO_NAME=calico-3.15-python2
+            - export VERSION=release-v3.15-python2
+            - export FELIX_CHECKOUT=master
+            - export PACKAGE_ETCD3GW=true
+            - make release-publish
         - name: 'Current release branch'
           commands:
             - export REPO_NAME=calico-current

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 
-.PHONY: release-publish
+.PHONY: release-publish release
 VERSION ?= master
 release-publish:
+	VERSION=$(VERSION) PUBLISH=true utils/create-update-packages.sh
+release:
 	VERSION=$(VERSION) utils/create-update-packages.sh

--- a/docker-build-images/install-centos-build-deps
+++ b/docker-build-images/install-centos-build-deps
@@ -7,6 +7,10 @@ yum install -y rpm-build \
                make \
                git \
                gcc \
+               python-setuptools \
+               python-pbr \
+	       python2-devel \
+	       python-urllib3 \
                python3-setuptools \
                python3-pbr \
                python3-devel \

--- a/docker-build-images/install-centos-build-deps
+++ b/docker-build-images/install-centos-build-deps
@@ -9,8 +9,8 @@ yum install -y rpm-build \
                gcc \
                python-setuptools \
                python-pbr \
-	       python2-devel \
-	       python-urllib3 \
+               python2-devel \
+               python-urllib3 \
                python3-setuptools \
                python3-pbr \
                python3-devel \

--- a/docker-build-images/install-ubuntu-build-deps
+++ b/docker-build-images/install-ubuntu-build-deps
@@ -7,11 +7,12 @@ apt-get install -y build-essential  \
                    devscripts \
                    debhelper \
                    dh-systemd \
+                   python-all \
+                   python-setuptools \
                    python3-all \
                    python3-setuptools \
                    libyajl2 \
                    libdatrie1 \
-                   python3-pbr \
                    git \
                    libnetfilter-conntrack-dev \
                    libidn11-dev \

--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -226,11 +226,15 @@ function do_felix {
 
 function do_etcd3gw {
     pushd ${rootdir}/etcd3gw
-    # We don't have Python 3 RPM packaging for etcd3gw, so it makes
-    # sense to retreat to the same solution as for Debian/Ubuntu:
-    # don't build etcd3gw packages, and instead document that 'pip
-    # install' should be used to install etcd3gw.
-    # PKG_NAME=python-etcd3gw ../utils/make-packages.sh rpm
+    if ${PACKAGE_ETCD3GW:-false}; then
+	# When PACKAGE_ETCD3GW is explicitly specified, build RPM Python 2 packages for etcd3gw.
+	PKG_NAME=python-etcd3gw ../utils/make-packages.sh rpm
+    else
+        # Otherwise, no-op.  We don't have Python 3 RPM packaging for etcd3gw, so it makes sense to
+	# retreat to the same solution as for Debian/Ubuntu: don't build etcd3gw packages, and
+	# instead document that 'pip install' should be used to install etcd3gw.
+	:
+    fi
     popd
 }
 

--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -23,11 +23,16 @@ scriptdir=$(dirname $(realpath $0))
 . ${scriptdir}/lib.sh
 rootdir=`git_repo_root`
 
+pub_steps=
+if "${PUBLISH:-false}"; then
+    pub_steps="pub_debs pub_rpms"
+fi
+
 if [ "${SEMAPHORE_GIT_PR_NUMBER}${SEMAPHORE_GIT_BRANCH}" = master -o -z "${SEMAPHORE_GIT_BRANCH}" ]; then
     # Normally - if not Semaphore, or if this is Semaphore running on
     # the master branch and not for a PR - do all the steps including
     # publication.
-    : ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle pub_debs pub_rpms}
+    : ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle ${pub_steps}}
 else
     # For Semaphore building a PR or a branch other than master, build
     # packages but do not publish them.


### PR DESCRIPTION
A few loosely-related improvements here, motivated by approaching v3.15.

1. Automation for building packages for the current and previous release branches, as well as for master.  I've separately created the "calico-current" and "calico-previous" PPAs, and will follow-up with Wavetank and calico-test changes to test against the master, calico-current and calico-previous PPAs instead of the current numbered system.

2. Restoring the ability to package with Python 2, as well as with Python 3.  We still need Python 2 capability for 3.15, as well as for previous release - d'oh.

    a. For Python 2 releases, restoring the ability to build RPM packages for etcd3gw.

3. Making it easier - for testing - to build all the packages without publishing them (`make release`).

4. Remove PBR dependency from Ubuntu images.  We now only use PBR for etcd3gw, and we only build RPMs for etcd3gw.