### PR TITLE
Updates for Calico v3.16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,12 +42,10 @@ blocks:
         - name: 'Current release branch'
           commands:
             - export REPO_NAME=calico-current
-            - export VERSION=release-v3.15
-            - export PACKAGE_ETCD3GW=true
+            - export VERSION=release-v3.16
             - make release-publish
         - name: 'Previous release branch'
           commands:
             - export REPO_NAME=calico-previous
-            - export VERSION=release-v3.14
-            - export PACKAGE_ETCD3GW=true
+            - export VERSION=release-v3.15
             - make release-publish


### PR DESCRIPTION
- Current release series is now v3.16.
- Previous release series is now v3.15.

Those are both Python 3, so we don't package etcd3gw because we don't
have any Python 3 packaging for etcd3gw.