### PR TITLE
Adjustments for building ubuntu focal packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Published column.
 
 We build and publish packages for these platforms:
 
--  Ubuntu 14.04 (Trusty), 16.04 (Xenial) and 18.04 (Bionic).  The
-   hosting for these packages is in PPAs at
-   https://launchpad.net/~project-calico.
+-  Ubuntu 14.04 (Trusty), 16.04 (Xenial), 18.04 (Bionic)
+   and 20.04 (Focal). The hosting for these packages is
+   in PPAs at https://launchpad.net/~project-calico.
 
 -  CentOS 7 or RHEL 7.  The hosting for these packages is in RPM repos
    at binaries.projectcalico.org (for example
@@ -164,9 +164,9 @@ releases is as follows.
 -  v2.79
 
 To get all of these patches requires Dnsmasq v2.79 or later.  Ubuntu
-Bionic has that, but none of our other target platforms do, so we
-build and host v2.79 packages for those platforms ourselves.  The
-source for that comes from the following tags in [our Dnsmasq
+Bionic or later have that, but none of our other target platforms do,
+so we build and host v2.79 packages for those platforms ourselves.
+The source for that comes from the following tags in [our Dnsmasq
 fork](https://github.com/projectcalico/calico-dnsmasq).
 
 -  For Ubuntu Trusty, `2.79test1calico1-3-trusty`.

--- a/docker-build-images/install-ubuntu-build-deps
+++ b/docker-build-images/install-ubuntu-build-deps
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -x
 set -e
-
 apt-get update
+DEBIAN_FRONTEND=noninteractive \
 apt-get install -y build-essential  \
                    devscripts \
                    debhelper \
                    dh-systemd \
+                   dh-python \
                    python-all \
                    python-setuptools \
                    python3-all \

--- a/docker-build-images/ubuntu-focal-build.Dockerfile.amd64
+++ b/docker-build-images/ubuntu-focal-build.Dockerfile.amd64
@@ -1,0 +1,8 @@
+FROM ubuntu:focal
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+ENV STREAM focal
+
+ADD install-ubuntu-build-deps install-ubuntu-build-deps
+RUN ./install-ubuntu-build-deps
+
+WORKDIR /code

--- a/docker-build-images/ubuntu-focal-build.Dockerfile.ppc64le
+++ b/docker-build-images/ubuntu-focal-build.Dockerfile.ppc64le
@@ -1,0 +1,8 @@
+FROM ppc64le/ubuntu:focal
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+ENV STREAM focal
+
+ADD install-ubuntu-build-deps install-ubuntu-build-deps
+RUN ./install-ubuntu-build-deps
+
+WORKDIR /code

--- a/utils/create-update-packages.sh
+++ b/utils/create-update-packages.sh
@@ -167,6 +167,7 @@ function do_bld_images {
     docker build -f ubuntu-trusty-build.Dockerfile.${ARCH} -t calico-build/trusty .
     docker build -f ubuntu-xenial-build.Dockerfile.${ARCH} -t calico-build/xenial .
     docker build -f ubuntu-bionic-build.Dockerfile.${ARCH} -t calico-build/bionic .
+    docker build -f ubuntu-focal-build.Dockerfile.${ARCH} -t calico-build/focal .
     docker build --build-arg=UID=`id -u` --build-arg=GID=`id -g` -f centos7-build.Dockerfile.${ARCH} -t calico-build/centos7 .
     popd
     if [ $ARCH = ppc64le ]; then

--- a/utils/make-packages.sh
+++ b/utils/make-packages.sh
@@ -46,7 +46,7 @@ for package_type in "$@"; do
 	    # Current time in Debian changelog format; e.g. Wed, 02
 	    # Mar 2016 14:08:51 +0000.
 	    timestamp=`date "+%a, %d %b %Y %H:%M:%S %z"`
-	    for series in trusty xenial bionic; do
+	    for series in trusty xenial bionic focal; do
 		{
 		    cat <<EOF
 ${PKG_NAME} (${DEB_EPOCH}${debver}-$series) $series; urgency=low

--- a/utils/publish-debs.sh
+++ b/utils/publish-debs.sh
@@ -18,7 +18,7 @@ else
 fi
 docker run --rm ${interactive} -v `pwd`:/code -v ${keydir}:/keydir calico-build/bionic /bin/sh -c "gpg --import --batch < /keydir/key && debsign -k'*@' *_*_source.changes"
 
-for series in trusty xenial bionic; do
+for series in trusty xenial bionic focal; do
     # Get the packages and versions that already exist in the PPA, so we can avoid
     # uploading the same package and version as already exist.  (As they would be rejected
     # anyway by Launchpad.)
@@ -30,13 +30,13 @@ for series in trusty xenial bionic; do
     # Use the Distribution header to map changes files to Ubuntu versions, as some of our
     # packages don't include the Ubuntu version name in the changes file name.
     for changes_file in `grep -l "Distribution: ${series}" *_source.changes`; do
-	already_exists=false
-	for existing in ${existing_packages}; do
-	    if [ ${changes_file} = ${existing}_source.changes ]; then
-		already_exists=true
-		break
-	    fi
-	done
-	${already_exists} || docker run --rm -v `pwd`:/code -w /code calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file}
+        already_exists=false
+        for existing in ${existing_packages}; do
+            if [ ${changes_file} = ${existing}_source.changes ]; then
+                already_exists=true
+                break
+            fi
+        done
+        ${already_exists} || docker run --rm -v `pwd`:/code -w /code calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file}
     done
 done


### PR DESCRIPTION
This depends on networking-calico PR #48 to build properly.

- Added docker images based on existing ones
- Adjusted scripts' loops to include focal along with other versions
- Install dh-python dependency on ubuntu docker containers
- Updated docs to mention focal along with other versions
- Adjusted identation (removed tabs)

Fixes #4216